### PR TITLE
Update notification endpoints for query params, not path

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -978,10 +978,10 @@ paths:
         '200':
           description: OK
       summary: Save your user settings.
-  /user/notifications/{status}:
+  /user/notifications:
     get:
       parameters:
-        - in: path 
+        - in: query
           name: status
           required: true
           schema:
@@ -990,8 +990,19 @@ paths:
               - all
               - new
               - read
+        - in: query
+          name: page
+          required: false
+          schema:
+            type: string
+            default: 1
       tags:
         - User
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserNotifications'
       responses:
         '200':
           description: OK
@@ -1000,23 +1011,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/NotificationsResponse'          
       summary: Get your user notifications
-  /user/notifications/{notif_id}/{read_status}:
+  /user/notification_status:
     put:
       parameters:
-        - in: path
+        - in: query
           name: notif_id
           required: true
           schema:
             type: integer
             example: 1234
-        - in: path
+        - in: query
           name: read_status
           required: true
           schema: 
             type: string
             enum:
-              - read
-              - unread
+              - true
+              - false
       tags:
         - User
       responses:
@@ -1027,7 +1038,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/NotificationsReadStatusResponse'
       summary: Set the read status of a given notification.
-      
   /upload/image:
     post:
       tags:
@@ -3415,6 +3425,14 @@ components:
           type: string
           example: https://preferred.social/static/media/image.png
       type: object
+    UserNotifications:
+      properties:
+        status:
+          title: UserNotifications.status
+          type: string
+        page:
+          title: UserNotifications.page
+          type: string
     NotificationsResponse:
       properties:
         counts:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1062,6 +1062,7 @@ paths:
             application/json:
               schema:  
                 $ref: '#/components/schemas/BadRequest'                
+      summary: Get user unread notifications count.
   /user/mark_all_notifications_read:
     put:
       tags:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -987,9 +987,9 @@ paths:
           schema:
             type: string
             enum:
-              - all
-              - new
-              - read
+              - All
+              - New
+              - Read
         - in: query
           name: page
           required: false
@@ -998,11 +998,6 @@ paths:
             default: 1
       tags:
         - User
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UserNotifications'
       responses:
         '200':
           description: OK
@@ -1010,8 +1005,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NotificationsResponse'          
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'                
       summary: Get your user notifications
-  /user/notification_status:
+  /user/notification_state:
     put:
       parameters:
         - in: query
@@ -1021,7 +1022,7 @@ paths:
             type: integer
             example: 1234
         - in: query
-          name: read_status
+          name: read_state
           required: true
           schema: 
             type: string
@@ -1037,7 +1038,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NotificationsReadStatusResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:  
+                $ref: '#/components/schemas/BadRequest'                
       summary: Set the read status of a given notification.
+  /user/notifications_count:
+    get:
+      tags:
+        - User
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationsCountResponse'    
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:  
+                $ref: '#/components/schemas/BadRequest'                
+  /user/mark_all_notifications_read:
+    put:
+      tags:
+        - User
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationsMarkAllReadResponse'    
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:  
+                $ref: '#/components/schemas/BadRequest'         
+      summary: Set all unread user notifications to read.
+
   /upload/image:
     post:
       tags:
@@ -3425,14 +3468,6 @@ components:
           type: string
           example: https://preferred.social/static/media/image.png
       type: object
-    UserNotifications:
-      properties:
-        status:
-          title: UserNotifications.status
-          type: string
-        page:
-          title: UserNotifications.page
-          type: string
     NotificationsResponse:
       properties:
         counts:
@@ -3455,7 +3490,7 @@ components:
         status:
           title: NotificationsResponse.status
           type: string
-          example: new
+          example: New
         user:
           title: NotificationsResponse.user
           type: string
@@ -3772,4 +3807,22 @@ components:
         - $ref: '#/components/schemas/NotificationsItemFeedView'
         - $ref: '#/components/schemas/NotificationsItemPostMentionView'
         - $ref: '#/components/schemas/NotificationsItemCommentMentionView' 
+    NotificationsCountResponse:
+      title: NotificationsCountResponse
+      type: object
+      properties:
+        count:
+          title: NotificationsCountResponse.count
+          type: integer
+          example: 42
+    NotificationsMarkAllReadResponse:
+      title: NotificationsMarkAllReadResponse
+      type: object
+      properties:
+        mark_all_notifications_as_read:
+          title: NotificationsMarkAllReadResponse.mark_all_notifications_as_read
+          type: string
+          example: complete
+
+          
   


### PR DESCRIPTION
The `/user/notifications` and `/user/notification_state`  endpoints are being adjusted to use request args rather than path params, so this adjusts the swagger to match.

This also adds `/user/notifications_count` and `/user/mark_all_notifications_read` endpoints.

endpoints PR: https://codeberg.org/rimu/pyfedi/pulls/619